### PR TITLE
Connection attempt window limit fix

### DIFF
--- a/src/Fleck/ConnectionLimiter.cs
+++ b/src/Fleck/ConnectionLimiter.cs
@@ -65,8 +65,10 @@ namespace Fleck
                     state.WindowStart = now;
                     state.AttemptCount = 0;
                 }
-
-                state.AttemptCount++;
+                else
+                {
+                    state.AttemptCount++;
+                }
 
                 if (_maxAttemptsPerWindow != -1 && state.AttemptCount >= _maxAttemptsPerWindow)
                 {


### PR DESCRIPTION
Fix for the connection attempt window limit kicking in after 4 attempts instead of the intended 5